### PR TITLE
WIP V14: Create property editor ui

### DIFF
--- a/SeoVisualizer/Client/package.json
+++ b/SeoVisualizer/Client/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build --emptyOutDir",
-    "watch": "tsc && vite build --watch",
+    "watch": "tsc && vite build --watch --emptyOutDir",
     "generate:api": "openapi-ts",
     "preview": "vite preview"
   },

--- a/SeoVisualizer/Client/src/models/constants.ts
+++ b/SeoVisualizer/Client/src/models/constants.ts
@@ -1,0 +1,2 @@
+﻿export const DEFAULT_MAX_CHARS_TITLE = 60;
+export const DEFAULT_MAX_CHARS_DESCRIPTION = 160;

--- a/SeoVisualizer/Client/src/models/seo-values.ts
+++ b/SeoVisualizer/Client/src/models/seo-values.ts
@@ -1,0 +1,6 @@
+﻿export interface SeoValues {
+    title: string;
+    description: string;
+    noIndex: boolean;
+    excludeTitleSuffix: boolean;
+}

--- a/SeoVisualizer/Client/src/property-editor/manifests.ts
+++ b/SeoVisualizer/Client/src/property-editor/manifests.ts
@@ -1,4 +1,5 @@
 import { ManifestPropertyEditorSchema, ManifestPropertyEditorUi } from '@umbraco-cms/backoffice/extension-registry';
+import {DEFAULT_MAX_CHARS_DESCRIPTION, DEFAULT_MAX_CHARS_TITLE} from "../models/constants.ts";
 
 const schema : ManifestPropertyEditorSchema = {
     type : 'propertyEditorSchema',
@@ -36,11 +37,11 @@ const schema : ManifestPropertyEditorSchema = {
             defaultData : [
                 {
                     alias : "maxCharsTitle",
-                    value : 60
+                    value : DEFAULT_MAX_CHARS_TITLE
                 },
                 {
                     alias : "maxCharsDescription",
-                    value : 160
+                    value : DEFAULT_MAX_CHARS_DESCRIPTION
                 }
             ]
         }

--- a/SeoVisualizer/Client/src/property-editor/manifests.ts
+++ b/SeoVisualizer/Client/src/property-editor/manifests.ts
@@ -7,18 +7,40 @@ const schema : ManifestPropertyEditorSchema = {
     meta : {
         defaultPropertyEditorUiAlias : 'EnkelMedia.SeoVisualizer.PropertyEditorUi',
         settings : {
-            properties : [
+            properties: [
                 {
-                    alias : 'min',
-                    label : 'Minimum number of items',
-                    description : '',
-                    propertyEditorUiAlias : 'Umb.PropertyEditorUi.Integer'
+                    label : "Recommended number of characters for Title warning",
+                    description : "Will show warning when the title contains more chars than defined. (Default is 60).",
+                    alias : "maxCharsTitle",
+                    propertyEditorUiAlias : "Umb.PropertyEditorUi.Integer"
                 },
                 {
-                    alias : 'max',
-                    label : 'Maximum number of items',
-                    description : '',
-                    propertyEditorUiAlias : 'Umb.PropertyEditorUi.Integer'
+                    label : "Recommended number of characters for Description warning",
+                    description : "Will show warning when the description contains more chars than defined. (Default is 160).",
+                    alias : "maxCharsDescription",
+                    propertyEditorUiAlias : "Umb.PropertyEditorUi.Integer",
+                },
+                {
+                    label : "Default Title Suffix",
+                    description : "Will append a suffix to the Title preview (not included in the saved data)",
+                    alias : "titleSuffix",
+                    propertyEditorUiAlias : "Umb.PropertyEditorUi.TextBox"
+                },
+                {
+                    label : "Show noindex-option",
+                    description : "Use this to show a noindex-toggle in the editor",
+                    alias : "useNoIndex",
+                    propertyEditorUiAlias : "Umb.PropertyEditorUi.Toggle"
+                }
+            ],
+            defaultData : [
+                {
+                    alias : "maxCharsTitle",
+                    value : 60
+                },
+                {
+                    alias : "maxCharsDescription",
+                    value : 160
                 }
             ]
         }

--- a/SeoVisualizer/Client/src/property-editor/seo-visualizer-property-editor-ui.element.ts
+++ b/SeoVisualizer/Client/src/property-editor/seo-visualizer-property-editor-ui.element.ts
@@ -1,35 +1,208 @@
-import { LitElement,css,html,customElement,property} from '@umbraco-cms/backoffice/external/lit';
+import { LitElement,css,html,customElement,property, state} from '@umbraco-cms/backoffice/external/lit';
 import { UmbElementMixin } from '@umbraco-cms/backoffice/element-api';
 import { UmbTextStyles } from '@umbraco-cms/backoffice/style';
+import {UmbPropertyEditorConfigCollection, UmbPropertyValueChangeEvent} from "@umbraco-cms/backoffice/property-editor";
+import {DEFAULT_MAX_CHARS_DESCRIPTION, DEFAULT_MAX_CHARS_TITLE} from "../models/constants.ts";
+import {SeoValues} from "../models/seo-values.ts";
 
 /**
 * seo-visualizer-property-editor-ui description
 * @element seo-visualizer-property-editor-ui
-* @fires CustomEvent#change - lorem ipsum 
+* @fires CustomEvent#change - lorem ipsum
 * @cssprop --ns-foo-bar - Color of lorem
 */
 @customElement('seo-visualizer-property-editor-ui')
 export class SeoVisualizerPropertyEditorUiElement extends UmbElementMixin(LitElement) {
 
-    /**
-    * Description 
-    */
-    @property({type:Boolean})
-    disabled : boolean = false;
+    @property()
+    public value?: Partial<SeoValues>;
+
+    @property()
+    private _titleSuffix?: string;
+
+    @property()
+    private _maxCharsTitle: number = DEFAULT_MAX_CHARS_TITLE;
+
+    @property()
+    private _maxCharsDescription: number = DEFAULT_MAX_CHARS_DESCRIPTION;
+
+    @state()
+    private _useNoIndex: boolean = false;
+
+    @state()
+    private _showExcludeTitleSuffix: boolean = false;
+
+    public set config(config: UmbPropertyEditorConfigCollection | undefined) {
+        this._useNoIndex = config?.getValueByAlias('useNoIndex') ?? false;
+        this._titleSuffix = config?.getValueByAlias('titleSuffix');
+        this._showExcludeTitleSuffix  = !!(this._titleSuffix && this._titleSuffix !== '');
+        this._maxCharsTitle = config?.getValueByAlias('maxCharsTitle') ?? DEFAULT_MAX_CHARS_TITLE;
+        this._maxCharsDescription = config?.getValueByAlias('maxCharsDescription') ?? DEFAULT_MAX_CHARS_DESCRIPTION;
+    }
+
+    #dispatchChangeEvent() {
+        this.dispatchEvent(new UmbPropertyValueChangeEvent());
+    }
+
+    #onTitleInput(e: InputEvent) {
+        this.value = {...this.value, title: (e.target as HTMLInputElement).value};
+        this.#dispatchChangeEvent();
+    }
+
+    #onDescriptionInput(e: InputEvent) {
+        this.value = {...this.value, description: (e.target as HTMLInputElement).value};
+        this.#dispatchChangeEvent();
+    }
+
+    #onNoIndexToggle(e: InputEvent) {
+        this.value = {...this.value, noIndex: (e.target as HTMLInputElement).checked};
+        this.#dispatchChangeEvent();
+    }
+
+    #onExcludeTitleSuffixToggle(e: InputEvent) {
+        this.value = {...this.value, excludeTitleSuffix: (e.target as HTMLInputElement).checked};
+        this.#dispatchChangeEvent();
+    }
+
+    getTitle(): string {
+        let title = '';
+
+        if (this.value?.title && this.value.title !== '') {
+
+            title = this.value.title;
+        }
+
+        // TODO: Take the current node name if title is empty
+
+        // Only append suffix if we have a value to render.
+        if (title === '') {
+            return title;
+        }
+
+        // Only append suffix if there is a value set
+        if (this.value && this._showExcludeTitleSuffix && !this.value.excludeTitleSuffix) {
+            return `${title} ${this._titleSuffix}`;
+        } else {
+            return title;
+        }
+    }
+
+    getUrl(): string {
+        // TODO: retrieve the current node url
+        return "WIP";
+    }
 
     render() {
         return html`
-            <div>
-                seo-visualizer-property-editor-ui
-            </div>
-        `
+            <div class="sv-form">
+                <div>
+                    <uui-input placeholder="${this.localize.term('seoVisualizer_title_placeholder')}"
+                               @input=${this.#onTitleInput}
+                               .value=${this.value?.title || ""}></uui-input>
+                    <!-- TODO: <p class="sv-error">${this.localize.term('seoVisualizer_max_length', this._maxCharsTitle)}</p>-->
+                </div>
+                <div>
+                    <uui-textarea placeholder="${this.localize.term('seoVisualizer_description_placeholder')}"
+                                  @input=${this.#onDescriptionInput}
+                                  .value=${this.value?.description || ""}></uui-textarea>
+                        <!-- TODO: <p class="sv-error">${this.localize.term('seoVisualizer_max_length', this._maxCharsDescription)}</p>-->
+                </div>
+                ${ (this._useNoIndex || this._showExcludeTitleSuffix) ?
+                html`
+                    <div class="sv-options">
+                        ${this._showExcludeTitleSuffix ?
+                        html`
+                                <uui-toggle .checked="${this.value?.excludeTitleSuffix || false}"
+                                            @change="${this.#onExcludeTitleSuffixToggle}">
+                                    ${this.localize.term('seoVisualizer_exclude_title_suffix')}
+                                </uui-toggle>
+                        ` : ''}
+                        ${this._useNoIndex ?
+                        html`
+                                <uui-toggle .checked="${this.value?.noIndex || false}"
+                                            @change="${this.#onNoIndexToggle}">
+                                    ${this.localize.term('seoVisualizer_no_index')}
+                                </uui-toggle>
+                        ` : ''}
+                    </div>
+                ` : ''}
 
+            </div>
+            <div class="sv-demo">
+                <h6>${this.getTitle()}</h6>
+                <p class="sv-url">${this.getUrl()}</p>
+                <p>${this.value?.description || ""}</p>
+            </div>
+        `;
     }
 
     static styles = [UmbTextStyles, css`
+        /* containers */
+        .sv-form {
+            width: 400px;
+            float: left;
+            margin-right: 40px;
+        }
 
-        :host {
-            --lorem-ipsum : var(--lorem-ipsum2,#ff00ff);
+        .sv-demo {
+            max-width: 600px; /* The width of the desktop-SERP as of 2019-11-14 */
+            width: auto;
+            float: left;
+        }
+
+        /* form elements */
+
+        .sv-form > div + div {
+            margin-top: 10px;
+        }
+
+        .sv-form input, div.sv-form textarea {
+            width: 100%;
+        }
+
+        .sv-form textarea {
+            height: 100px;
+        }
+
+        /* general text formating */
+
+        .sv-demo h6, .sv-demo p {
+            font-family: Arial, Helvectiva, sans-serif;
+            padding: 0;
+            margin: 0;
+        }
+
+        /* form text formating */
+
+        .sv-form p.sv-error {
+            visibility: hidden;
+            color: red;
+            margin-top: 3px;
+        }
+
+        .sv-form p.sv-error.seo-invisible {
+            visibility: initial;
+        }
+
+        /* demo-mode text formating */
+
+        .sv-demo h6 {
+            font-size: 20px;
+            line-height: 1.3;
+            margin-bottom: 3px;
+            color: blue;
+            text-decoration: underline;
+        }
+
+        .sv-demo p {
+            font-size: 14px;
+            margin-bottom: 3px;
+            line-height: 1.57;
+            word-wrap: break-word;
+        }
+
+        .sv-demo p.sv-url {
+            color: #00802a;
         }
     `]
 }


### PR DESCRIPTION
Migrating the old AngularJS component to Lit-element one
See #32 

I've taken the liberty of sticking with the same type of inputs as in v13, in order to keep a similar style, i.e. : 

- uui-input for the meta title
- uui-textarea for the meta description
- uui-toggle for true/false choices (no-index, show title prefix)

TODO:
- [X] Switch to Lit-element
- [X] Data type settings
- [X] Save and retrieve data
- [ ] Current node things as name and url for the google snippet
- [ ] Recommended max length messages visibility
- [ ] Tests