### PR TITLE
Color refresh, bug fix, 2nd attempt

### DIFF
--- a/SeoVisualizer/Client/src/property-editor/seo-visualizer-property-editor-ui.element.ts
+++ b/SeoVisualizer/Client/src/property-editor/seo-visualizer-property-editor-ui.element.ts
@@ -232,7 +232,7 @@ export class SeoVisualizerPropertyEditorUiElement extends UmbFormControlMixin<Se
               rows="6"
               placeholder=${this.localize.term('seoVisualizer_description_placeholder')}
             ></uui-textarea>
-            ${when((this.value?.title?.length ?? 0) > this._configRecommendedDescriptionLength,()=>html`
+            ${when((this.value?.description?.length ?? 0) > this._configRecommendedDescriptionLength,()=>html`
               <p class="error">${this.localize.term('seoVisualizer_max_length',this._configRecommendedDescriptionLength)}</p>
             `)}
           </div>
@@ -282,7 +282,6 @@ export class SeoVisualizerPropertyEditorUiElement extends UmbFormControlMixin<Se
     }
 
     #preview h6, #preview p {
-      font-family: Arial, Helvectiva, san-serif;
       padding: 0;
       margin: 0;
     }
@@ -291,8 +290,8 @@ export class SeoVisualizerPropertyEditorUiElement extends UmbFormControlMixin<Se
       font-size: 20px;
       line-height: 1.3;
       margin-bottom: 3px;
-      color: blue;
-      text-decoration: underline;
+      color: var(--uui-color-focus);
+      text-decoration: none;
     }
 
     #preview p {
@@ -303,11 +302,11 @@ export class SeoVisualizerPropertyEditorUiElement extends UmbFormControlMixin<Se
     }
 
     #preview p.url {
-      color: #00802a;
+      color: var(--uui-color-text-alt);
     }
 
     p.error {
-      color: red;
+      color: var(--uui-color-invalid);
       margin:0;
     }
 


### PR DESCRIPTION
Updated color scheme to support Umbraco's Dark Theme and look slightly more modern

Also fixed a bug with the description max length

![Skærmbillede 2025-04-29 kl  09 44 51](https://github.com/user-attachments/assets/1e8b049e-eb21-4def-8f73-3b8658ce12ee)
![Skærmbillede 2025-04-29 kl  09 44 56](https://github.com/user-attachments/assets/f8ddcf24-e6c5-40f3-ac4e-6ca1cc3437bd)


Since the v14 branch is marked as default, i accidentally forked the wrong branch - Should be better now :)